### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/pdftags
+++ b/pdftags
@@ -565,7 +565,7 @@ class MainWindow(Gtk.Window):
         else:
             self.pages.set_text('')
         if pdf.doi:
-            self.doi.set_markup('<a href="https://dx.doi.org/{0}">{0}</a>'.format(pdf.doi))
+            self.doi.set_markup('<a href="https://doi.org/{0}">{0}</a>'.format(pdf.doi))
         else:
             self.doi.set_text('')
 


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR suggests that change, to what I understand is code that generates new DOI links.

Cheers :-)